### PR TITLE
Adjust staking rate calculations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.formatOnSave": true,
-  "solidity.formatter": "forge",
+  "solidity.formatter": "prettier",
   "[solidity]": {
     "editor.defaultFormatter": "JuanBlanco.solidity"
   },

--- a/script/DeployTestnet.s.sol
+++ b/script/DeployTestnet.s.sol
@@ -27,7 +27,7 @@ contract DeployTestnetScript is Script {
         usdTest.mint(testWallet, 1_000_000e6);
 
         CGV cgv = new CGV();
-        cgv.mint(testWallet, 1_000_000_000e6);
+        cgv.mint(testWallet, 1_000_000e6);
 
         GCoin gcoin = new GCoin();
 
@@ -38,7 +38,12 @@ contract DeployTestnetScript is Script {
 
         gcoin.addStableCoin(address(usdTest));
 
-        GCoinStaking gCoinStaking = new GCoinStaking(address(gcoin), address(cgv), 10 minutes, 1);
+        GCoinStaking gCoinStaking = new GCoinStaking(
+            address(gcoin),
+            address(cgv),
+            100
+        );
+        cgv.mint(address(gCoinStaking), 10_000_000e6);
 
         vm.stopBroadcast();
 
@@ -47,7 +52,11 @@ contract DeployTestnetScript is Script {
         vm.serializeAddress(json, "Treasury", address(treasury));
         vm.serializeAddress(json, "CGV", address(cgv));
         vm.serializeAddress(json, "USDTest", address(usdTest));
-        string memory finalJson = vm.serializeAddress(json, "GCoinStaking", address(gCoinStaking));
+        string memory finalJson = vm.serializeAddress(
+            json,
+            "GCoinStaking",
+            address(gCoinStaking)
+        );
         string memory file = string.concat("./deploy/", network, ".json");
         vm.writeJson(finalJson, file);
         console.log("Contract addresses saved to %s", file);

--- a/script/PauseGcoin.s.sol
+++ b/script/PauseGcoin.s.sol
@@ -8,7 +8,8 @@ import "../src/Treasury.sol";
 
 contract PauseGcoin is Script {
     function run() external {
-        string memory json = vm.readFile("./deploy/test.json");
+        string memory network = vm.envOr("NETWORK", string("localhost"));
+        string memory json = vm.readFile(string.concat("./deploy/", network, ".json"));
         address gcoinAddress = vm.parseJsonAddress(json, ".GCoin");
 
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");

--- a/src/GCoinStaking.sol
+++ b/src/GCoinStaking.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import "openzeppelin-contracts/contracts/access/Ownable.sol";
@@ -12,22 +11,25 @@ import "openzeppelin-contracts/contracts/security/Pausable.sol";
 
 contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
     using SafeMath for uint256;
-    using SafeERC20 for IERC20;
+    using SafeERC20 for ERC20;
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    IERC20 public gcoinToken;
-    IERC20 public cgvToken;
+    ERC20 public gcoinToken;
+    ERC20 public cgvToken;
+
+    uint8 cgvDecimals;
+    uint8 gcoinDecimals;
+
+    // Base of 100, ie. 20% = 20
     uint256 public annualRewardRate;
 
-    uint256 public MIN_STAKING_DURATION = 180 days;
+    uint256 public MIN_STAKING_DURATION = 7 days;
     uint256 public MAX_STAKING_DURATION = 4 * 365 days;
     /*
     this scale 50 means 0.5, which means new_reward_rate = reward_rate + 0.5 * orig_reward_rate * time
     Total reward = new_reward_rate * time
     */
     uint256 public REWARD_SCALE = 50;
-
-
 
     struct Stake {
         uint256 amount;
@@ -51,29 +53,42 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
     event Paused();
     event Unpaused();
 
-
-    constructor(address _gcoinToken, address _cgvToken, uint256 _annualRewardRate) {
-        gcoinToken = IERC20(_gcoinToken);
-        cgvToken = IERC20(_cgvToken);
+    constructor(
+        address _gcoinToken,
+        address _cgvToken,
+        uint256 _annualRewardRate
+    ) {
+        gcoinToken = ERC20(_gcoinToken);
+        cgvToken = ERC20(_cgvToken);
         annualRewardRate = _annualRewardRate;
-    }
 
+        cgvDecimals = cgvToken.decimals();
+        gcoinDecimals = gcoinToken.decimals();
+    }
 
     // Users can stake GCoin tokens
     function stake(uint256 amount, uint256 duration) external whenNotPaused {
-        require(duration >= MIN_STAKING_DURATION, "Staking duration is too short.");
-        require(duration <= MAX_STAKING_DURATION, "Staking duration is too long.");
+        require(
+            duration >= MIN_STAKING_DURATION,
+            "Staking duration is too short."
+        );
+        require(
+            duration <= MAX_STAKING_DURATION,
+            "Staking duration is too long."
+        );
 
         uint256 rewardMultiplier = calculateRewardRate(duration);
 
         gcoinToken.safeTransferFrom(msg.sender, address(this), amount);
         UserInfo storage userInfo = userStakingInfo[msg.sender];
-        userInfo.stakes.push(Stake({
-            amount: amount,
-            timestamp: block.timestamp,
-            duration: duration,
-            rewardMultiplier: rewardMultiplier
-        }));
+        userInfo.stakes.push(
+            Stake({
+                amount: amount,
+                timestamp: block.timestamp,
+                duration: duration,
+                rewardMultiplier: rewardMultiplier
+            })
+        );
         userAddresses.add(msg.sender);
         emit Staked(msg.sender, amount, duration);
     }
@@ -91,7 +106,10 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
                 currentStake.timestamp
             );
             if (stakedDuration >= currentStake.duration) {
-                uint256 reward = calculateReward(currentStake.amount, currentStake.duration);
+                uint256 reward = calculateReward(
+                    currentStake.amount,
+                    currentStake.duration
+                );
                 totalRewards = totalRewards.add(reward);
                 totalAmount = totalAmount.add(currentStake.amount);
 
@@ -116,22 +134,23 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
         emit Withdrawn(msg.sender, totalAmount, totalRewards);
     }
 
-
     // Users can withdraw their matured stakes along with the rewards
-    function withdrawSpecific(uint256 index) external nonReentrant whenNotPaused {
+    function withdrawSpecific(
+        uint256 index
+    ) external nonReentrant whenNotPaused {
         UserInfo storage userInfo = userStakingInfo[msg.sender];
 
         Stake storage currentStake = userInfo.stakes[index];
-        uint256 stakedDuration = block.timestamp.sub(
-            currentStake.timestamp
-        );
+        uint256 stakedDuration = block.timestamp.sub(currentStake.timestamp);
         if (stakedDuration >= currentStake.duration) {
-            uint256 reward = calculateReward(currentStake.amount, currentStake.duration);
+            uint256 reward = calculateReward(
+                currentStake.amount,
+                currentStake.duration
+            );
             require(
                 cgvToken.balanceOf(address(this)) >= reward,
                 "Not enough CGV tokens to pay rewards. We are adding more. Please wait"
             );
-
 
             gcoinToken.safeTransfer(msg.sender, currentStake.amount);
             cgvToken.safeTransfer(msg.sender, reward);
@@ -144,25 +163,37 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
         }
     }
 
-
-    function calculateReward(uint256 amount, uint256 duration) public view returns (uint256) {
-        uint256 newRewardRate = calculateRewardRate(duration);
-        return amount.mul(newRewardRate)
-                    .div(100)
-                    .mul(duration)
-                    .div(365 days);
+    /**
+     * @dev Returns the quantity of CGV rewards for a given GCOIN amount and duration
+     */
+    function calculateReward(
+        uint256 amount,
+        uint256 duration
+    ) public view returns (uint256) {
+        return
+            _convertDecimals(amount, gcoinDecimals, cgvDecimals)
+                .mul(calculateRewardRate(duration))
+                .mul(duration)
+                .div(365 days)
+                .div(100);
     }
 
-    function calculateRewardRate(uint256 duration) public view returns (uint256) {
-        uint256 newRewardRate = annualRewardRate + annualRewardRate.mul(REWARD_SCALE).mul(duration).div(365 days).div(100);
-        return newRewardRate;
+    /**
+     * @dev Returns the annual rate of CGV rewards for a given duration
+     */
+    function calculateRewardRate(
+        uint256 duration
+    ) public view returns (uint256) {
+        return
+            annualRewardRate +
+            annualRewardRate.mul(REWARD_SCALE).mul(duration).div(365 days).div(
+                100
+            );
     }
 
-    function getUserStakingInfoList(address user)
-        external
-        view
-        returns (UserInfo memory)
-    {
+    function getUserStakingInfoList(
+        address user
+    ) external view returns (UserInfo memory) {
         return userStakingInfo[user];
     }
 
@@ -173,10 +204,9 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
     // }
 
     // Owner can update the annual reward rate
-    function updateAnnualRewardRate(uint256 _annualRewardRate)
-        external
-        onlyOwner
-    {
+    function updateAnnualRewardRate(
+        uint256 _annualRewardRate
+    ) external onlyOwner {
         annualRewardRate = _annualRewardRate;
         emit AnnualRewardRateUpdated(_annualRewardRate);
     }
@@ -191,11 +221,13 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
         emit Unpaused();
     }
 
-    function getUserStakingInfo(address user)
-        public
-        view
-        returns (uint256 totalStaked, uint256 outstandingCGV)
-    {
+    /**
+     * @dev Returns the amount staked and pending rewards for a user,
+     * including vested rewards that have not yet unlocked
+     */
+    function getUserStakingInfo(
+        address user
+    ) public view returns (uint256 totalStaked, uint256 outstandingCGV) {
         UserInfo storage userInfo = userStakingInfo[user];
         totalStaked = 0;
         outstandingCGV = 0;
@@ -205,14 +237,19 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
             uint256 stakedDuration = block.timestamp.sub(
                 currentStake.timestamp
             );
-            if (stakedDuration >= currentStake.duration) {
-                uint256 reward = calculateReward(currentStake.amount, currentStake.duration);
-                outstandingCGV = outstandingCGV.add(reward);
-            }
+            uint256 reward = calculateReward(
+                currentStake.amount,
+                stakedDuration
+            );
+            outstandingCGV = outstandingCGV.add(reward);
             totalStaked = totalStaked.add(currentStake.amount);
         }
     }
 
+    /**
+     * @dev Returns the total pending rewards for all users,
+     * including vested rewards that have not yet unlocked
+     */
     function getTotalOutstandingRewards() external view returns (uint256) {
         uint256 totalOutstandingRewards = 0;
         for (uint256 i = 0; i < userAddresses.length(); i++) {
@@ -225,15 +262,24 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
         return totalOutstandingRewards;
     }
 
+    /**
+     * @dev Returns the total staked gcoin for all users
+     */
     function getTotalLockedValue() external view returns (uint256) {
         uint256 totalStaked = 0;
         for (uint256 i = 0; i < userAddresses.length(); i++) {
             address user = userAddresses.at(i);
             (uint256 totalStakedUser, ) = getUserStakingInfo(user);
-            totalStaked = totalStaked.add(
-                totalStakedUser
-            );
+            totalStaked = totalStaked.add(totalStakedUser);
         }
         return totalStaked;
+    }
+
+    function _convertDecimals(
+        uint256 value,
+        uint8 from,
+        uint8 to
+    ) private pure returns (uint256) {
+        return value.mul(10 ** to).div(10 ** from);
     }
 }

--- a/src/GCoinStaking.sol
+++ b/src/GCoinStaking.sol
@@ -203,7 +203,9 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
     //     emit StakingPeriodUpdated(_stakingPeriod);
     // }
 
-    // Owner can update the annual reward rate
+    /**
+     * @dev Owner can update the annual reward rate
+     */
     function updateAnnualRewardRate(
         uint256 _annualRewardRate
     ) external onlyOwner {
@@ -223,7 +225,7 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
 
     /**
      * @dev Returns the amount staked and pending rewards for a user,
-     * including vested rewards that have not yet unlocked
+     * including accrued rewards that have not yet unlocked
      */
     function getUserStakingInfo(
         address user
@@ -248,7 +250,7 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
 
     /**
      * @dev Returns the total pending rewards for all users,
-     * including vested rewards that have not yet unlocked
+     * including accrued rewards that have not yet unlocked
      */
     function getTotalOutstandingRewards() external view returns (uint256) {
         uint256 totalOutstandingRewards = 0;
@@ -275,6 +277,9 @@ contract GCoinStaking is Ownable, ReentrancyGuard, Pausable {
         return totalStaked;
     }
 
+    /**
+     * @dev Converts the {value} originally denominated in {from} decimals to {to} decimals
+     */
     function _convertDecimals(
         uint256 value,
         uint8 from,


### PR DESCRIPTION
Two notable changes:
- `getUserStakingInfo` should include accrued but locked rewards, for frontend display
- `calculateReward` should account for decimals