### PR TITLE
Add a function for treasury to approve spending

### DIFF
--- a/src/Treasury.sol
+++ b/src/Treasury.sol
@@ -42,10 +42,21 @@ contract Treasury is Ownable {
         TM = _newTM;
     }
 
-    function defendLowerBound(uint256 amount, address stableCoin)
-        external
-        onlyTM
-    {
+    /**
+     * @dev Approve spending for token, eg. for GCoin to spend stablecoins for redemptions
+     */
+    function approveFor(
+        address token,
+        address spender,
+        uint256 amount
+    ) public onlyOwner {
+        ERC20(token).approve(spender, amount);
+    }
+
+    function defendLowerBound(
+        uint256 amount,
+        address stableCoin
+    ) external onlyTM {
         uint256 currentPrice = gcoin.getGCoinValue();
         /*
         Figure out how to get traded price, maybe this is just manually controled by TM
@@ -82,10 +93,10 @@ why the AMM price go up above 1.02? If so, arbitrager will mint from GCoin and s
 
  */
 
-    function defendUpperBound(uint256 amount, address stableCoin)
-        external
-        onlyTM
-    {
+    function defendUpperBound(
+        uint256 amount,
+        address stableCoin
+    ) external onlyTM {
         uint256 currentPrice = gcoin.getGCoinValue();
         /*
         Figure out how to get traded price, maybe this is just manually controled by TM
@@ -115,31 +126,31 @@ why the AMM price go up above 1.02? If so, arbitrager will mint from GCoin and s
         _;
     }
 
-    function addToLiquidReserve(address asset, uint256 amount)
-        external
-        onlyOwner
-    {
+    function addToLiquidReserve(
+        address asset,
+        uint256 amount
+    ) external onlyOwner {
         liquidReserve[asset] = liquidReserve[asset].add(amount);
     }
 
-    function removeFromLiquidReserve(address asset, uint256 amount)
-        external
-        onlyOwner
-    {
+    function removeFromLiquidReserve(
+        address asset,
+        uint256 amount
+    ) external onlyOwner {
         liquidReserve[asset] = liquidReserve[asset].sub(amount);
     }
 
-    function addToIlliquidReserve(address asset, uint256 amount)
-        external
-        onlyOwner
-    {
+    function addToIlliquidReserve(
+        address asset,
+        uint256 amount
+    ) external onlyOwner {
         illiquidReserve[asset] = illiquidReserve[asset].add(amount);
     }
 
-    function removeFromIlliquidReserve(address asset, uint256 amount)
-        external
-        onlyOwner
-    {
+    function removeFromIlliquidReserve(
+        address asset,
+        uint256 amount
+    ) external onlyOwner {
         illiquidReserve[asset] = illiquidReserve[asset].sub(amount);
     }
 

--- a/test/GCoin.t.sol
+++ b/test/GCoin.t.sol
@@ -37,6 +37,11 @@ contract GCoinTest is Test {
         gcoin = new GCoin();
         address[] memory arr = new address[](0);
         treasury = new Treasury(address(gcoin), msg.sender, arr, arr);
+        treasury.approveFor(
+            address(stablecoin6digit),
+            address(gcoin),
+            type(uint256).max
+        );
 
         // Set treasury address in the GCoin contract
         gcoin.setTreasury(address(treasury));
@@ -115,10 +120,6 @@ contract GCoinTest is Test {
         gcoin.addStableCoin(address(stablecoin6digit));
         stablecoin6digit.mint(gcoin.treasury(), 4e6);
         gcoin.mint(address(this), 1e18);
-
-        vm.startPrank(address(gcoin.treasury()));
-        stablecoin6digit.approve(address(gcoin), 1e18);
-        vm.stopPrank();
 
         gcoin.withdrawStableCoin(address(stablecoin6digit), 1e18);
 


### PR DESCRIPTION
Since GCOIN redemptions transfer stables from treasury, we need a way to call `approve`